### PR TITLE
Avoid NPE

### DIFF
--- a/extension/src/main/java/io/quarkus/bot/build/reporting/extension/ReportingMavenExtension.java
+++ b/extension/src/main/java/io/quarkus/bot/build/reporting/extension/ReportingMavenExtension.java
@@ -37,8 +37,7 @@ public class ReportingMavenExtension extends AbstractMavenLifecycleParticipant {
     private Logger logger;
 
     @Override
-    public void afterSessionEnd(MavenSession session)
-            throws MavenExecutionException {
+    public void afterSessionEnd(MavenSession session) {
 
         MavenExecutionResult result = session.getResult();
         List<MavenProject> projects = result.getTopologicallySortedProjects();


### PR DESCRIPTION
Without this patch, the presence of this plugin could potentially fail the build with an NPE in Quarkus.

( The underlying cause was that the code wasn't compiling because of a bug in javac )