### PR TITLE
Analyze the test path after it being created

### DIFF
--- a/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReporterActionHandler.java
+++ b/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReporterActionHandler.java
@@ -134,8 +134,6 @@ public class BuildReporterActionHandler {
                 final Path newPath = getZipEntryPath(jobDirectory, zipEntry);
                 final File newFile = newPath.toFile();
 
-                buildReportsBuilder.addPath(newPath);
-
                 if (zipEntry.isDirectory()) {
                     if (!newFile.isDirectory() && !newFile.mkdirs()) {
                         throw new IOException("Failed to create directory " + newFile);
@@ -154,6 +152,9 @@ public class BuildReporterActionHandler {
 
                     fos.close();
                 }
+
+                buildReportsBuilder.addPath(newPath);
+
                 zipEntry = zis.getNextEntry();
             }
             zis.closeEntry();

--- a/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReports.java
+++ b/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReports.java
@@ -3,7 +3,8 @@ package io.quarkus.bot.buildreporter.githubactions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -68,7 +69,7 @@ class BuildReports {
         private Path gradleBuildScanUrlPath;
         private Set<TestResultsPath> testResultsPaths = new TreeSet<>();
 
-        private Set<Path> alreadyTreatedPaths = new HashSet<>();
+        private Map<Path, Boolean> alreadyTreatedPaths = new HashMap<>();
 
         Builder(Path jobDirectory) {
             this.jobDirectory = jobDirectory;
@@ -100,7 +101,11 @@ class BuildReports {
         }
 
         private boolean addTestPath(Path path) {
-            if (path == null || alreadyTreatedPaths.contains(path)) {
+            return alreadyTreatedPaths.computeIfAbsent(path, p -> doAddTestPath(p));
+        }
+
+        private boolean doAddTestPath(Path path) {
+            if (path == null) {
                 return true;
             }
 

--- a/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReportsUnarchiver.java
+++ b/build-reporter-github-actions/src/main/java/io/quarkus/bot/buildreporter/githubactions/BuildReportsUnarchiver.java
@@ -98,8 +98,6 @@ class BuildReportsUnarchiver {
                     final Path newPath = getZipEntryPath(jobDirectory, zipEntry);
                     final File newFile = newPath.toFile();
 
-                    buildReportsBuilder.addPath(newPath);
-
                     if (zipEntry.isDirectory()) {
                         if (!newFile.isDirectory() && !newFile.mkdirs()) {
                             throw new IOException("Failed to create directory " + newFile);
@@ -120,6 +118,9 @@ class BuildReportsUnarchiver {
 
                         fos.close();
                     }
+
+                    buildReportsBuilder.addPath(newPath);
+
                     zipEntry = zis.getNextEntry();
                 }
                 zis.closeEntry();


### PR DESCRIPTION
We added a test checking for isDirectory() a while ago and it will only return true if the file is already on disk.

This was an issue in practice only if there was only one file and it became a lot more apparent with the caching I will introduce in the follow-up commit.